### PR TITLE
First-char/last-char spaces in OutputTextNoBr will be preserved

### DIFF
--- a/lib/_io.js
+++ b/lib/_io.js
@@ -97,7 +97,13 @@ function msg(s, params, cssClass) {
 //@DOC 
 //Output a standard message, but it makes the NEXT message appear on the same line as the current message. Note that the next message will not have its own params or cssClass. 
 function OutputTextNoBr(s, params, cssClass) {
-   msg("@@SAMELINE@@" + s, params, cssClass);
+    if(s.startsWith(' ')) {
+        s = "&nbsp;" + s.substring(1, s.length);
+    }
+    if(s.endsWith(' ')) {
+        s = s.substring(0, (s.length - 1)) + "&nbsp;"
+    }
+   msg("@@OUTPUTTEXTNOBR@@" + s, params, cssClass);
 }
 function msgBlankLine() {
   _msg('', false, {tag:'p', printBlank:true})
@@ -844,7 +850,7 @@ io.print = function(data) {
   
   if (data.html) {
     html = data.html
-  }
+  } 
   else if (io.sameLine == false){
     html = '<' + data.tag + ' id="n' + data.id + '"'
     if (data.cssClass) html += ' class="' + data.cssClass + '"'
@@ -859,16 +865,14 @@ io.print = function(data) {
   }
   else {
       
-      let keepSL = (html.indexOf("@@SAMELINE@@") > -1)
+      let keepSL = (html.indexOf("@@OUTPUTTEXTNOBR@@") > -1)
       let slID = "n" + (data.id-1) 
       if(keepSL == true) {
-          html = html.replace("@@SAMELINE@@", "");
+          html = html.replace("@@OUTPUTTEXTNOBR@@", "");
       }
       if(io.sameLine == true) { 
         let last = document.getElementById(slID)
-        console.log("ABOUT TO PRINT " + html + "ON " + last.innerHTML)
         last.innerHTML = last.innerHTML + html
-        console.log (last.innerHTML)
         io.sameLine = false 
       }
       else {


### PR DESCRIPTION
Added some code to preserve spaces at the end of OutputTextNoBr. This allows for syntax like 

OutputTextNoBr("Hello ");

if(someVar == true) {
    msg("WORLD")
}
else {
    msg("Universe!")
}

Which I feel reads a little better. I also changed the code word to OUTPUTTEXTNOBR instead of SAMELINE, which I feel is a little more consistent and less likely to run into accidental collisions down the line. 
