### PR TITLE
Show or Hide item links after movement

### DIFF
--- a/lib/item-links.js
+++ b/lib/item-links.js
@@ -154,7 +154,7 @@ itemLinks.itemLinkClick = function(el) {
 //---
 itemLinks.disableItemLink = function(el) {
   el.children[0].removeAttribute('onclick')
-  el.classList.remove('object-link')
+  //el.classList.remove('object-link')
   el.classList.remove('dropdown')
   el.children[0].classList.remove('droplink')
   //el.style.cursor = 'default'
@@ -171,7 +171,8 @@ itemLinks.disableItemLink = function(el) {
 itemLinks.updateItemLinks = function(el) {
   const obj = w[el.dataset.objname]
   const alias = el.children[0].innerHTML
-  el.innerHTML = settings.nameTransformer(alias, obj)
+  el.innerHTML = null
+  el.outerHTML = settings.nameTransformer(alias, obj)
 }
 
 


### PR DESCRIPTION
I noticed with the original item-links code, items outside of the current view/scope would still be linked and have dropdowns but just return "not here" messages when clicked. This will disable the link on items that are no longer in scope so they display as regular text, and re-enable the link when they are within scope again