### PR TITLE
fixed typo in list.js

### DIFF
--- a/rpg/lists.js
+++ b/rpg/lists.js
@@ -5,7 +5,7 @@ rpg.lists = {
   stones:["alabaster", "soapstone", "chlorite", "wonderstone", "limestone", "onyx", "obsidian", "marble", "moonstone", "coral", "amber"],
   metals:[
     "mithril",
-    "high gold".
+    "high gold",
     "royal gold",
     "gold",
     "crown gold",
@@ -24,7 +24,7 @@ rpg.lists = {
     "brass",
     "white copper",
     "copper",
-    "cast iron".
+    "cast iron",
     "wrought iron",
     "iron",
     "pewter",


### PR DESCRIPTION
Uncaught SyntaxError: missing name after . operator

a typo in the rpg libraries where a list had some periods instead of commas.

This is also my first commit to open source software wao :)